### PR TITLE
Progress bug

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Test
       run: go test -short -v  ./... -coverpkg "github.com/prequel-dev/plz4,github.com/prequel-dev/plz4/internal/...,github.com/prequel-dev/plz4/pkg/..." -coverprofile coverage.out
     - name: Upload coverage as artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: coverage.out
         path: coverage.out
@@ -37,7 +37,7 @@ jobs:
         contents: write  # This grants write access to the repository, including the Wiki.  
     steps:
     - name: Download coverage artifact
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: coverage.out
         path: ~/coverage.out

--- a/internal/pkg/rdr/rdr.go
+++ b/internal/pkg/rdr/rdr.go
@@ -220,7 +220,9 @@ func (r *Reader) nextBlock() (err error) {
 }
 
 func (r *Reader) modeHeader(dst []byte) (int, error) {
-	_, err := r._readHeader()
+	n, err := r._readHeader()
+
+	r.srcPos += int64(n)
 
 	if err != nil {
 		return 0, err

--- a/plz4_opts.go
+++ b/plz4_opts.go
@@ -104,6 +104,7 @@ func WithWorkerPool(wp WorkerPool) OptT {
 // Offsets are relative to the start of the frame.
 //
 // Note: Callback may be called from a secondary goroutine.
+// However, offsets will emit in order from only that goroutine.
 func WithProgress(cb CbProgressT) OptT {
 	return func(o *opts.OptsT) {
 		o.Handler = cb


### PR DESCRIPTION
Offsets on the read progress callback were misaligned.

- Did not account for the header size on the Read() case.
- Did not account for block header size (and possibly blk checksum) in the uncompressable case.